### PR TITLE
Feature/de 13429 add codeowners to resonate

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -19,9 +19,6 @@ Dockerfile         @resonate/shield
 **/*.tf            @resonate/shield
 **/*.hcl           @resonate/shield
 
-# Amazon States Language (Step Functions) definitions
-**/*.asl           @resonate/shield
-
 # Bash scripts
 **/*.sh           @resonate/shield
 **/*.bash         @resonate/shield
@@ -33,8 +30,11 @@ Dockerfile         @resonate/shield
 # AVENGERS — Spring Boot services
 # ──────────────────────────────────────────────────────────────────────────────
 
-# Java source under the typical Spring Boot layout
-src/main/java/**   @resonate/avengers
+# Javascript / TS Code
+**/*.js           @resonate/avengers
+**/*.ts           @resonate/avengers
+**/*.jsx          @resonate/avengers
+**/*.tsx          @resonate/avengers
 
 # Common build files for Spring Boot apps
 pom.xml            @resonate/avengers


### PR DESCRIPTION
## Summary
Adding Generic Code owners file to resonate to try and capture most basic level of code ownership changes. 

## Type of Change
<!-- Select the type(s) of change you have introduced -->
- [X] New feature

## Detailed Description
Added a very generic codeowners file to the .github repo for resonate which acts as a global store for files such as this. Repo owners should ideally still commit an actual codeowners file which has ownership defined properly. The idea is for this to serve as a catch all for cases where changes are made that people may not be familiar with who to request reviews from. 

## Reviewer Notes
This might be overkill for some teams but repo structure around here is different across many repos so i tried to get as much as i could.
